### PR TITLE
Implement dashboard layout with persistent sidebar

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,42 +1,642 @@
-#root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
+.app-shell {
+  display: flex;
+  min-height: 100vh;
+  background: #f5f7fb;
+  color: #1f2937;
+}
+
+.sidebar {
+  width: 264px;
+  background: #ffffff;
+  border-right: 1px solid #e6ecf5;
+  padding: 28px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.05);
+}
+
+.sidebar__brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.sidebar__brand-logo {
+  width: 44px;
+  height: 44px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, #6953fe, #7f8eff);
+  color: #ffffff;
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+  font-size: 1.1rem;
+}
+
+.sidebar__brand-text h2 {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 600;
+}
+
+.sidebar__brand-text span {
+  font-size: 0.85rem;
+  color: #6b7280;
+}
+
+.sidebar__nav {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.sidebar__bottom {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.sidebar__nav-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  border: none;
+  background: transparent;
+  color: #4b5563;
+  font-size: 0.95rem;
+  font-weight: 500;
+  padding: 12px 16px;
+  border-radius: 14px;
+  transition: background 0.2s ease, color 0.2s ease;
+  cursor: pointer;
+}
+
+.sidebar__nav-item svg {
+  width: 20px;
+  height: 20px;
+  stroke: currentColor;
+  stroke-width: 1.6;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  fill: none;
+}
+
+.sidebar__nav-item--active {
+  background: linear-gradient(135deg, rgba(103, 89, 255, 0.18), rgba(103, 89, 255, 0.05));
+  color: #3d38ce;
+}
+
+.sidebar__nav-item:hover {
+  background: rgba(103, 89, 255, 0.08);
+  color: #3d38ce;
+}
+
+.sidebar__nav-item--secondary {
+  color: #64748b;
+}
+
+.sidebar__nav-item--secondary:hover {
+  background: rgba(15, 23, 42, 0.04);
+  color: #334155;
+}
+
+.app-main {
+  flex: 1;
+  padding: 32px 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.app-content {
+  flex: 1;
+}
+
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #ffffff;
+  border-radius: 24px;
+  padding: 20px 28px;
+  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.06);
+}
+
+.topbar__title h1 {
+  margin: 4px 0 0;
+  font-size: 1.6rem;
+  font-weight: 600;
+  color: #111827;
+}
+
+.topbar__subtitle {
+  margin: 0;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: #9ca3af;
+}
+
+.topbar__actions {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+}
+
+.topbar__search {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: #f4f6fc;
+  border-radius: 18px;
+  padding: 10px 16px;
+}
+
+.topbar__search input {
+  border: none;
+  background: transparent;
+  outline: none;
+  font-size: 0.95rem;
+  color: #374151;
+}
+
+.topbar__search input::placeholder {
+  color: #9ca3af;
+}
+
+.topbar__icon {
+  width: 18px;
+  height: 18px;
+  stroke: #6b7280;
+  stroke-width: 1.8;
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.topbar__pill {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border: none;
+  background: #f4f6fc;
+  padding: 10px 16px;
+  border-radius: 16px;
+  font-size: 0.9rem;
+  color: #374151;
+  cursor: pointer;
+}
+
+.topbar__icon-button {
+  position: relative;
+  width: 44px;
+  height: 44px;
+  border-radius: 16px;
+  border: none;
+  background: #f4f6fc;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+}
+
+.topbar__indicator {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #ff6b6b, #f43f5e);
+}
+
+.topbar__profile {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.topbar__avatar {
+  width: 46px;
+  height: 46px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, #fcd34d, #f97316);
+  color: #ffffff;
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+}
+
+.topbar__name {
+  margin: 0;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.topbar__role {
+  font-size: 0.8rem;
+  color: #9ca3af;
+}
+
+.placeholder {
+  background: #ffffff;
+  border-radius: 24px;
+  padding: 48px;
   text-align: center;
+  color: #64748b;
+  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.05);
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+.placeholder h2 {
+  margin-top: 0;
+  color: #334155;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+.dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
+.dashboard__cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+
+.summary-card {
+  background: #ffffff;
+  border-radius: 24px;
+  padding: 24px;
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  box-shadow: 0 16px 30px rgba(15, 23, 42, 0.04);
+}
+
+.summary-card__badge {
+  width: 56px;
+  height: 56px;
+  border-radius: 20px;
+  flex-shrink: 0;
+}
+
+.summary-card__content h3 {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #6b7280;
+}
+
+.summary-card__value {
+  margin: 10px 0 4px;
+  font-size: 1.6rem;
+  font-weight: 600;
+  color: #111827;
+}
+
+.summary-card__change {
+  display: block;
+  font-size: 0.9rem;
+  color: #34d399;
+  font-weight: 600;
+}
+
+.summary-card__hint {
+  display: block;
+  font-size: 0.82rem;
+  color: #9ca3af;
+}
+
+.summary-card--peach .summary-card__badge {
+  background: linear-gradient(135deg, rgba(249, 115, 22, 0.18), rgba(249, 115, 22, 0.36));
+}
+
+.summary-card--lavender .summary-card__badge {
+  background: linear-gradient(135deg, rgba(129, 140, 248, 0.18), rgba(99, 102, 241, 0.32));
+}
+
+.summary-card--mint .summary-card__badge {
+  background: linear-gradient(135deg, rgba(16, 185, 129, 0.18), rgba(16, 185, 129, 0.32));
+}
+
+.summary-card--sky .summary-card__badge {
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.18), rgba(37, 99, 235, 0.32));
+}
+
+.dashboard__main {
+  display: grid;
+  grid-template-columns: minmax(0, 2.2fr) minmax(0, 1fr);
+  gap: 24px;
+  align-items: stretch;
 }
 
 .card {
-  padding: 2em;
+  background: #ffffff;
+  border-radius: 28px;
+  padding: 28px;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.07);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
 }
 
-.read-the-docs {
-  color: #888;
+.card--wide {
+  gap: 32px;
+}
+
+.card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.card__header h2 {
+  margin: 0;
+  font-size: 1.3rem;
+  font-weight: 600;
+  color: #111827;
+}
+
+.card__subtitle {
+  margin: 4px 0 0;
+  font-size: 0.9rem;
+  color: #9ca3af;
+}
+
+.card__filter {
+  border: none;
+  background: #f4f6fc;
+  border-radius: 16px;
+  padding: 10px 16px;
+  font-size: 0.9rem;
+  color: #374151;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+}
+
+.card__filter svg {
+  width: 16px;
+  height: 16px;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.order-chart {
+  position: relative;
+}
+
+.order-chart__canvas {
+  width: 100%;
+  height: 260px;
+}
+
+.order-chart__grid {
+  stroke: #edf1f9;
+  stroke-width: 1;
+}
+
+.order-chart__area {
+  stroke: none;
+}
+
+.order-chart__line {
+  stroke: #6759ff;
+  stroke-width: 4;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.order-chart__dot {
+  fill: #ffffff;
+  stroke: #6759ff;
+  stroke-width: 3;
+}
+
+.order-chart__dot--active {
+  fill: #6759ff;
+}
+
+.order-chart__tooltip {
+  position: absolute;
+  transform: translate(-50%, -120%);
+  background: #111827;
+  color: #ffffff;
+  padding: 10px 14px;
+  border-radius: 12px;
+  text-align: center;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.2);
+}
+
+.order-chart__tooltip-value {
+  display: block;
+  font-weight: 600;
+}
+
+.order-chart__tooltip-label {
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.order-chart__axis {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  font-size: 0.85rem;
+  color: #9ca3af;
+  text-align: center;
+}
+
+.dashboard__aside {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.satisfaction__legend {
+  display: flex;
+  gap: 16px;
+  font-size: 0.8rem;
+  color: #6b7280;
+}
+
+.legend-dot {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  margin-right: 6px;
+}
+
+.legend-dot--primary {
+  background: #6759ff;
+}
+
+.legend-dot--muted {
+  background: #d1d5db;
+}
+
+.satisfaction__chart {
+  width: 100%;
+  height: 180px;
+}
+
+.satisfaction__line {
+  stroke: #6759ff;
+  stroke-width: 3;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.satisfaction__line--muted {
+  stroke: #d1d5db;
+  stroke-width: 2;
+}
+
+.satisfaction__labels {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(40px, 1fr));
+  font-size: 0.8rem;
+  color: #94a3b8;
+  text-align: center;
+}
+
+.alerts__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.alerts__item {
+  display: flex;
+  gap: 14px;
+  border-radius: 18px;
+  padding: 16px;
+  align-items: flex-start;
+}
+
+.alerts__status {
+  min-width: 62px;
+  padding: 6px 10px;
+  border-radius: 12px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  text-align: center;
+}
+
+.alerts__title {
+  margin: 0 0 6px;
+  font-weight: 600;
+  color: #111827;
+}
+
+.alerts__description {
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.alerts__item--warning {
+  background: rgba(254, 226, 226, 0.5);
+}
+
+.alerts__item--warning .alerts__status {
+  background: rgba(248, 113, 113, 0.2);
+  color: #b91c1c;
+}
+
+.alerts__item--caution {
+  background: rgba(254, 243, 199, 0.5);
+}
+
+.alerts__item--caution .alerts__status {
+  background: rgba(251, 191, 36, 0.2);
+  color: #b45309;
+}
+
+.alerts__item--positive {
+  background: rgba(209, 250, 229, 0.5);
+}
+
+.alerts__item--positive .alerts__status {
+  background: rgba(52, 211, 153, 0.2);
+  color: #047857;
+}
+
+@media (max-width: 1200px) {
+  .app-main {
+    padding: 28px;
+  }
+
+  .dashboard__main {
+    grid-template-columns: 1fr;
+  }
+
+  .dashboard__aside {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .dashboard__aside > .card {
+    flex: 1 1 280px;
+  }
+}
+
+@media (max-width: 960px) {
+  .app-shell {
+    flex-direction: column;
+  }
+
+  .sidebar {
+    width: auto;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    padding: 20px;
+  }
+
+  .sidebar__nav,
+  .sidebar__bottom {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .sidebar__nav-item {
+    padding: 10px 12px;
+  }
+}
+
+@media (max-width: 768px) {
+  .topbar {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 20px;
+  }
+
+  .topbar__actions {
+    width: 100%;
+    flex-wrap: wrap;
+  }
+
+  .dashboard__cards {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .app-main {
+    padding: 20px;
+  }
+
+  .card {
+    padding: 24px;
+  }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,34 +1,79 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import { useMemo, useState } from 'react'
+import Sidebar from './components/Sidebar.jsx'
+import TopBar from './components/TopBar.jsx'
+import Dashboard from './pages/Dashboard.jsx'
 import './App.css'
 
+const createPlaceholder = (label) => (
+  <div className="placeholder">
+    <h2>{label}</h2>
+    <p>The {label.toLowerCase()} module is under construction.</p>
+  </div>
+)
+
+const pageConfig = {
+  Dashboard: {
+    title: 'Supply Chain Overview',
+    subtitle: 'Dashboard',
+    element: <Dashboard />,
+  },
+  Orders: {
+    title: 'Orders',
+    subtitle: 'Orders',
+    element: createPlaceholder('Orders'),
+  },
+  TrainSchedule: {
+    title: 'Train Schedule',
+    subtitle: 'Train Schedule',
+    element: createPlaceholder('Train Schedule'),
+  },
+  VehicleUtilization: {
+    title: 'Vehicle Utilization',
+    subtitle: 'Vehicle Utilization',
+    element: createPlaceholder('Vehicle Utilization'),
+  },
+  ReportOverview: {
+    title: 'Report Overview',
+    subtitle: 'Report Overview',
+    element: createPlaceholder('Report Overview'),
+  },
+  UserManagement: {
+    title: 'User Management',
+    subtitle: 'User Management',
+    element: createPlaceholder('User Management'),
+  },
+  Settings: {
+    title: 'Settings',
+    subtitle: 'Settings',
+    element: createPlaceholder('Settings'),
+  },
+  SignOut: {
+    title: 'Sign Out',
+    subtitle: 'Sign Out',
+    element: (
+      <div className="placeholder">
+        <h2>Sign Out</h2>
+        <p>Your session remains active in this preview build.</p>
+      </div>
+    ),
+  },
+}
+
 function App() {
-  const [count, setCount] = useState(0)
+  const [activePage, setActivePage] = useState('Dashboard')
+
+  const { title, subtitle, element } = useMemo(() => {
+    return pageConfig[activePage] ?? pageConfig.Dashboard
+  }, [activePage])
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <div className="app-shell">
+      <Sidebar activePage={activePage} onNavigate={setActivePage} />
+      <main className="app-main">
+        <TopBar title={title} subtitle={subtitle} />
+        <div className="app-content">{element}</div>
+      </main>
+    </div>
   )
 }
 

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,0 +1,132 @@
+const navItems = [
+  { key: 'Dashboard', label: 'Dashboard', icon: 'dashboard' },
+  { key: 'Orders', label: 'Orders', icon: 'orders' },
+  { key: 'TrainSchedule', label: 'Train Schedule', icon: 'train' },
+  { key: 'VehicleUtilization', label: 'Vehicle Utilization', icon: 'vehicle' },
+  { key: 'ReportOverview', label: 'Report Overview', icon: 'report' },
+  { key: 'UserManagement', label: 'User Management', icon: 'users' },
+]
+
+const bottomItems = [
+  { key: 'Settings', label: 'Settings', icon: 'settings' },
+  { key: 'SignOut', label: 'Sign Out', icon: 'signout' },
+]
+
+const Icon = ({ type }) => {
+  switch (type) {
+    case 'dashboard':
+      return (
+        <svg viewBox="0 0 24 24" className="sidebar__icon" aria-hidden>
+          <rect x="3" y="3" width="8" height="8" rx="2" />
+          <rect x="13" y="3" width="8" height="8" rx="2" />
+          <rect x="3" y="13" width="8" height="8" rx="2" />
+          <rect x="13" y="13" width="8" height="8" rx="2" />
+        </svg>
+      )
+    case 'orders':
+      return (
+        <svg viewBox="0 0 24 24" className="sidebar__icon" aria-hidden>
+          <path d="M6 7h12l.8 10.4A2 2 0 0 1 16.82 19H7.18A2 2 0 0 1 5.2 17.4Z" />
+          <path d="M9 7V5a3 3 0 0 1 6 0v2" />
+        </svg>
+      )
+    case 'train':
+      return (
+        <svg viewBox="0 0 24 24" className="sidebar__icon" aria-hidden>
+          <rect x="6" y="5" width="12" height="10" rx="2" />
+          <path d="M6 13h12" />
+          <path d="M9 5V3h6v2" />
+          <path d="M9 19l-2 2" />
+          <path d="M15 19l2 2" />
+          <circle cx="10" cy="16.5" r="1.5" />
+          <circle cx="14" cy="16.5" r="1.5" />
+        </svg>
+      )
+    case 'vehicle':
+      return (
+        <svg viewBox="0 0 24 24" className="sidebar__icon" aria-hidden>
+          <path d="M3 8h9v7H3z" />
+          <path d="M12 11h4l3 4v3h-2.2" />
+          <circle cx="7.5" cy="18" r="1.8" />
+          <circle cx="16.5" cy="18" r="1.8" />
+        </svg>
+      )
+    case 'report':
+      return (
+        <svg viewBox="0 0 24 24" className="sidebar__icon" aria-hidden>
+          <circle cx="12" cy="12" r="8" />
+          <path d="M12 12V4a8 8 0 0 1 8 8h-8" />
+        </svg>
+      )
+    case 'users':
+      return (
+        <svg viewBox="0 0 24 24" className="sidebar__icon" aria-hidden>
+          <circle cx="9" cy="9" r="3" />
+          <circle cx="17" cy="10" r="2.5" />
+          <path d="M5 19a4 4 0 0 1 4-4h2a4 4 0 0 1 4 4" />
+          <path d="M15 18.5a4.5 4.5 0 0 1 4-2.5h.5" />
+        </svg>
+      )
+    case 'settings':
+      return (
+        <svg viewBox="0 0 24 24" className="sidebar__icon" aria-hidden>
+          <path d="m12 15 0 0a3 3 0 1 0 0-6 3 3 0 0 0 0 6z" />
+          <path d="m19.4 13.5-.7 1.2.3 1.4-1.2.7-1.4-.3-1.2.7-.7 1.2-1.4-.3-.7-1.2h-1.4l-.7 1.2-1.4.3-.7-1.2-1.2-.7-1.4.3-1.2-.7.3-1.4-.7-1.2L3 12l.7-1.2-.3-1.4 1.2-.7 1.4.3 1.2-.7.7-1.2 1.4.3.7 1.2h1.4l.7-1.2 1.4-.3.7 1.2 1.2.7 1.4-.3 1.2.7-.3 1.4.7 1.2Z" />
+        </svg>
+      )
+    case 'signout':
+      return (
+        <svg viewBox="0 0 24 24" className="sidebar__icon" aria-hidden>
+          <path d="M15 5h-6a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h6" />
+          <path d="m12 16 4-4-4-4" />
+          <path d="M16 12H5" />
+        </svg>
+      )
+    default:
+      return null
+  }
+}
+
+const Sidebar = ({ activePage, onNavigate }) => (
+  <aside className="sidebar">
+    <div className="sidebar__brand">
+      <div className="sidebar__brand-logo">K</div>
+      <div className="sidebar__brand-text">
+        <h2>Kandypack</h2>
+        <span>Dashboard</span>
+      </div>
+    </div>
+
+    <nav className="sidebar__nav">
+      {navItems.map((item) => (
+        <button
+          key={item.key}
+          type="button"
+          className={`sidebar__nav-item ${
+            activePage === item.key ? 'sidebar__nav-item--active' : ''
+          }`}
+          onClick={() => onNavigate(item.key)}
+        >
+          <Icon type={item.icon} />
+          <span>{item.label}</span>
+        </button>
+      ))}
+    </nav>
+
+    <div className="sidebar__bottom">
+      {bottomItems.map((item) => (
+        <button
+          key={item.key}
+          type="button"
+          className="sidebar__nav-item sidebar__nav-item--secondary"
+          onClick={() => onNavigate(item.key)}
+        >
+          <Icon type={item.icon} />
+          <span>{item.label}</span>
+        </button>
+      ))}
+    </div>
+  </aside>
+)
+
+export default Sidebar

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -1,0 +1,52 @@
+const SearchIcon = () => (
+  <svg viewBox="0 0 24 24" aria-hidden className="topbar__icon">
+    <circle cx="11" cy="11" r="6.5" />
+    <path d="m20 20-3.2-3.2" />
+  </svg>
+)
+
+const ChevronIcon = () => (
+  <svg viewBox="0 0 24 24" aria-hidden className="topbar__icon">
+    <path d="m8 10 4 4 4-4" />
+  </svg>
+)
+
+const BellIcon = () => (
+  <svg viewBox="0 0 24 24" aria-hidden className="topbar__icon">
+    <path d="M12 20a2 2 0 0 0 2-2H10a2 2 0 0 0 2 2Z" />
+    <path d="M18 16H6l1-1.5V11a5 5 0 0 1 10 0v3.5Z" />
+    <path d="M5 16h14" />
+  </svg>
+)
+
+const TopBar = ({ title, subtitle = 'Dashboard' }) => (
+  <header className="topbar">
+    <div className="topbar__title">
+      <p className="topbar__subtitle">{subtitle}</p>
+      <h1>{title}</h1>
+    </div>
+    <div className="topbar__actions">
+      <div className="topbar__search">
+        <SearchIcon />
+        <input type="text" placeholder="Search here..." />
+      </div>
+      <button type="button" className="topbar__pill">
+        Eng (US)
+        <ChevronIcon />
+      </button>
+      <button type="button" className="topbar__icon-button">
+        <BellIcon />
+        <span className="topbar__indicator" />
+      </button>
+      <div className="topbar__profile">
+        <div className="topbar__avatar">M</div>
+        <div>
+          <p className="topbar__name">Muffin</p>
+          <span className="topbar__role">Admin</span>
+        </div>
+      </div>
+    </div>
+  </header>
+)
+
+export default TopBar

--- a/src/index.css
+++ b/src/index.css
@@ -1,68 +1,40 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Poppins:wght@500;600&display=swap');
+
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'Inter', 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
+  color: #111827;
+  background-color: #f5f7fb;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
+*, *::before, *::after {
+  box-sizing: border-box;
 }
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
 a:hover {
-  color: #535bf2;
+  text-decoration: none;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
+  min-height: 100vh;
+  background: #f5f7fb;
+}
+
+#root {
   min-height: 100vh;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
+button,
+input {
   font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
 }

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,0 +1,280 @@
+const summaryCards = [
+  {
+    id: 'revenue',
+    title: 'Total Revenue',
+    value: '$6,500',
+    change: '+18% vs last week',
+    hint: 'Sales this month',
+    accent: 'peach',
+  },
+  {
+    id: 'orders',
+    title: 'New Orders',
+    value: '350',
+    change: '+12% vs last week',
+    hint: 'Orders this week',
+    accent: 'lavender',
+  },
+  {
+    id: 'deliveries',
+    title: 'On-Time Delivery',
+    value: '97.2%',
+    change: '+2.1% vs target',
+    hint: 'Delivered on schedule',
+    accent: 'mint',
+  },
+  {
+    id: 'satisfaction',
+    title: 'Customer Rating',
+    value: '4.8 / 5',
+    change: 'Based on 1.2k reviews',
+    hint: 'Customer feedback',
+    accent: 'sky',
+  },
+]
+
+const orderHistory = {
+  labels: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+  values: [24, 38, 29, 54, 48, 63, 58],
+}
+
+const satisfaction = {
+  labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'],
+  current: [74, 78, 84, 88, 92, 95],
+  previous: [68, 72, 76, 82, 86, 88],
+}
+
+const alerts = [
+  {
+    id: 1,
+    title: 'Delivery Delay',
+    description: '2 orders exceeded the SLA window.',
+    status: 'High',
+    tone: 'warning',
+  },
+  {
+    id: 2,
+    title: 'Inventory Threshold',
+    description: 'SKU-0981 and SKU-1023 are running low.',
+    status: 'Medium',
+    tone: 'caution',
+  },
+  {
+    id: 3,
+    title: 'Fleet Maintenance',
+    description: 'Vehicle KP-02 scheduled for inspection tomorrow.',
+    status: 'Low',
+    tone: 'positive',
+  },
+]
+
+const createPoints = (values, width, height) => {
+  if (values.length === 1) {
+    return [{ x: width / 2, y: height / 2 }]
+  }
+
+  const maxValue = Math.max(...values) * 1.15
+  const stepX = width / (values.length - 1)
+
+  return values.map((value, index) => {
+    const clamped = Math.max(0, value)
+    const ratio = clamped / maxValue
+    const x = index * stepX
+    const y = height - ratio * height
+    return { x, y }
+  })
+}
+
+const buildLinePath = (points) =>
+  points
+    .map((point, index) => `${index === 0 ? 'M' : 'L'}${point.x},${point.y}`)
+    .join(' ')
+
+const buildAreaPath = (points, width, height) =>
+  `M0,${height} ${points.map((point) => `L${point.x},${point.y}`).join(' ')} L${width},${height} Z`
+
+const Dashboard = () => {
+  const chartWidth = 620
+  const chartHeight = 240
+  const orderPoints = createPoints(orderHistory.values, chartWidth, chartHeight)
+  const orderHighlightIndex = orderHistory.values.indexOf(Math.max(...orderHistory.values))
+  const orderHighlight = orderPoints[orderHighlightIndex]
+
+  const smallChartWidth = 320
+  const smallChartHeight = 170
+  const satisfactionCurrent = createPoints(
+    satisfaction.current,
+    smallChartWidth,
+    smallChartHeight,
+  )
+  const satisfactionPrevious = createPoints(
+    satisfaction.previous,
+    smallChartWidth,
+    smallChartHeight,
+  )
+
+  return (
+    <div className="dashboard">
+      <section className="dashboard__cards">
+        {summaryCards.map((card) => (
+          <article key={card.id} className={`summary-card summary-card--${card.accent}`}>
+            <div className="summary-card__badge" />
+            <div className="summary-card__content">
+              <h3>{card.title}</h3>
+              <p className="summary-card__value">{card.value}</p>
+              <span className="summary-card__change">{card.change}</span>
+              <span className="summary-card__hint">{card.hint}</span>
+            </div>
+          </article>
+        ))}
+      </section>
+
+      <section className="dashboard__main">
+        <article className="card card--wide">
+          <header className="card__header">
+            <div>
+              <h2>Order History</h2>
+              <p className="card__subtitle">Weekly quantity overview</p>
+            </div>
+            <button type="button" className="card__filter">
+              Last 7 days
+              <svg viewBox="0 0 24 24" aria-hidden>
+                <path d="m8 10 4 4 4-4" />
+              </svg>
+            </button>
+          </header>
+
+          <div className="order-chart">
+            <svg
+              className="order-chart__canvas"
+              viewBox={`0 0 ${chartWidth} ${chartHeight}`}
+              preserveAspectRatio="none"
+            >
+              <defs>
+                <linearGradient id="orderGradient" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0%" stopColor="#6759ff" stopOpacity="0.26" />
+                  <stop offset="100%" stopColor="#6759ff" stopOpacity="0" />
+                </linearGradient>
+              </defs>
+
+              {[0.25, 0.5, 0.75].map((ratio) => (
+                <line
+                  key={ratio}
+                  x1="0"
+                  x2={chartWidth}
+                  y1={chartHeight * ratio}
+                  y2={chartHeight * ratio}
+                  className="order-chart__grid"
+                />
+              ))}
+
+              <path
+                d={buildAreaPath(orderPoints, chartWidth, chartHeight)}
+                fill="url(#orderGradient)"
+                className="order-chart__area"
+              />
+
+              <path
+                d={buildLinePath(orderPoints)}
+                className="order-chart__line"
+                fill="none"
+              />
+
+              {orderPoints.map((point, index) => (
+                <circle
+                  key={point.x}
+                  cx={point.x}
+                  cy={point.y}
+                  r={index === orderHighlightIndex ? 6 : 4}
+                  className={`order-chart__dot ${
+                    index === orderHighlightIndex ? 'order-chart__dot--active' : ''
+                  }`}
+                />
+              ))}
+            </svg>
+            <div
+              className="order-chart__tooltip"
+              style={{
+                left: `${(orderHighlight.x / chartWidth) * 100}%`,
+                top: `${(orderHighlight.y / chartHeight) * 100}%`,
+              }}
+            >
+              <span className="order-chart__tooltip-value">
+                {orderHistory.values[orderHighlightIndex]}%
+              </span>
+              <span className="order-chart__tooltip-label">Fulfilment rate</span>
+            </div>
+          </div>
+
+          <div className="order-chart__axis">
+            {orderHistory.labels.map((label) => (
+              <span key={label}>{label}</span>
+            ))}
+          </div>
+        </article>
+
+        <div className="dashboard__aside">
+          <article className="card satisfaction">
+            <header className="card__header">
+              <div>
+                <h2>Customer Satisfaction</h2>
+                <p className="card__subtitle">Support ticket resolution</p>
+              </div>
+              <div className="satisfaction__legend">
+                <span>
+                  <span className="legend-dot legend-dot--primary" /> This Month
+                </span>
+                <span>
+                  <span className="legend-dot legend-dot--muted" /> Last Month
+                </span>
+              </div>
+            </header>
+            <svg
+              className="satisfaction__chart"
+              viewBox={`0 0 ${smallChartWidth} ${smallChartHeight}`}
+              preserveAspectRatio="none"
+            >
+              <path
+                d={buildLinePath(satisfactionPrevious)}
+                className="satisfaction__line satisfaction__line--muted"
+                fill="none"
+              />
+              <path
+                d={buildLinePath(satisfactionCurrent)}
+                className="satisfaction__line"
+                fill="none"
+              />
+            </svg>
+            <div className="satisfaction__labels">
+              {satisfaction.labels.map((label) => (
+                <span key={label}>{label}</span>
+              ))}
+            </div>
+          </article>
+
+          <article className="card alerts">
+            <header className="card__header">
+              <div>
+                <h2>System Alerts</h2>
+                <p className="card__subtitle">Live monitoring</p>
+              </div>
+            </header>
+            <ul className="alerts__list">
+              {alerts.map((alert) => (
+                <li key={alert.id} className={`alerts__item alerts__item--${alert.tone}`}>
+                  <div className="alerts__status">{alert.status}</div>
+                  <div className="alerts__content">
+                    <p className="alerts__title">{alert.title}</p>
+                    <span className="alerts__description">{alert.description}</span>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </article>
+        </div>
+      </section>
+    </div>
+  )
+}
+
+export default Dashboard


### PR DESCRIPTION
## Summary
- add a persistent shell with sidebar navigation and top bar
- create a dashboard page with summary cards, charts, and alerts content
- refresh styling and typography for the new dashboard experience

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ccd0a3708c8329b11033f8659d6aef