### PR TITLE
Reorganize feature pages into component-based structure

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,10 @@ import { useMemo, useState } from 'react'
 import Sidebar from './components/Sidebar/Sidebar'
 import TopBar from './components/TopBar/TopBar'
 import Dashboard from './pages/Dashboard/Dashboard'
+import Orders from './pages/Orders/Orders'
+import TrainSchedule from './pages/TrainSchedule/TrainSchedule'
+import ReportOverview from './pages/ReportOverview/ReportOverview'
+import UserManagement from './pages/UserManagement/UserManagement'
 import './App.css'
 
 const createPlaceholder = (label) => (
@@ -20,12 +24,12 @@ const pageConfig = {
   Orders: {
     title: 'Orders',
     subtitle: 'Orders',
-    element: createPlaceholder('Orders'),
+    element: <Orders />,
   },
   TrainSchedule: {
     title: 'Train Schedule',
     subtitle: 'Train Schedule',
-    element: createPlaceholder('Train Schedule'),
+    element: <TrainSchedule />,
   },
   VehicleUtilization: {
     title: 'Vehicle Utilization',
@@ -35,12 +39,12 @@ const pageConfig = {
   ReportOverview: {
     title: 'Report Overview',
     subtitle: 'Report Overview',
-    element: createPlaceholder('Report Overview'),
+    element: <ReportOverview />,
   },
   UserManagement: {
     title: 'User Management',
     subtitle: 'User Management',
-    element: createPlaceholder('User Management'),
+    element: <UserManagement />,
   },
   Settings: {
     title: 'Settings',

--- a/src/components/orders/OrderStats/OrderStats.css
+++ b/src/components/orders/OrderStats/OrderStats.css
@@ -1,0 +1,49 @@
+.orders__stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap: 20px;
+}
+
+.orders__card {
+  background: #ffffff;
+  border-radius: 20px;
+  padding: 22px 24px;
+  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.orders__card--highlight {
+  background: linear-gradient(145deg, #2563eb, #4f46e5);
+  color: #ffffff;
+}
+
+.orders__card--highlight .orders__card-hint {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.orders__card-header h3 {
+  margin: 0;
+  font-size: 16px;
+  color: inherit;
+}
+
+.orders__card-value {
+  margin: 0;
+  font-size: 34px;
+  font-weight: 700;
+  color: inherit;
+}
+
+.orders__card-hint {
+  margin: 0;
+  color: #64748b;
+  font-size: 14px;
+}
+
+@media (max-width: 640px) {
+  .orders__card {
+    padding: 18px;
+  }
+}

--- a/src/components/orders/OrderStats/OrderStats.jsx
+++ b/src/components/orders/OrderStats/OrderStats.jsx
@@ -1,0 +1,20 @@
+import './OrderStats.css'
+
+const OrderStats = ({ stats }) => (
+  <section className="orders__stats">
+    {stats.map((stat) => (
+      <div
+        key={stat.id}
+        className={`orders__card ${stat.accent ? `orders__card--${stat.accent}` : ''}`.trim()}
+      >
+        <div className="orders__card-header">
+          <h3>{stat.title}</h3>
+        </div>
+        <p className="orders__card-value">{stat.value}</p>
+        <p className="orders__card-hint">{stat.hint}</p>
+      </div>
+    ))}
+  </section>
+)
+
+export default OrderStats

--- a/src/components/orders/OrderSummary/OrderSummary.css
+++ b/src/components/orders/OrderSummary/OrderSummary.css
@@ -1,0 +1,61 @@
+.orders__summary {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 24px;
+}
+
+.orders__summary-info h2 {
+  margin: 0 0 6px;
+  font-size: 28px;
+  color: #0f172a;
+}
+
+.orders__summary-info p {
+  margin: 0;
+  color: #64748b;
+}
+
+.orders__summary-actions {
+  display: flex;
+  gap: 12px;
+}
+
+.orders__button {
+  border: none;
+  border-radius: 12px;
+  padding: 12px 18px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.orders__button--secondary {
+  background: #e2e8f0;
+  color: #1e293b;
+}
+
+.orders__button--primary {
+  background: #2563eb;
+  color: #ffffff;
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.2);
+}
+
+.orders__button:hover {
+  transform: translateY(-1px);
+}
+
+@media (max-width: 960px) {
+  .orders__summary {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .orders__summary-actions {
+    width: 100%;
+  }
+
+  .orders__summary-actions button {
+    flex: 1;
+  }
+}

--- a/src/components/orders/OrderSummary/OrderSummary.jsx
+++ b/src/components/orders/OrderSummary/OrderSummary.jsx
@@ -1,0 +1,20 @@
+import './OrderSummary.css'
+
+const OrderSummary = () => (
+  <section className="orders__summary">
+    <div className="orders__summary-info">
+      <h2>Order Overview</h2>
+      <p>Track the latest order volume, fulfillment status, and customer deliveries.</p>
+    </div>
+    <div className="orders__summary-actions">
+      <button type="button" className="orders__button orders__button--secondary">
+        Export
+      </button>
+      <button type="button" className="orders__button orders__button--primary">
+        Add New Order
+      </button>
+    </div>
+  </section>
+)
+
+export default OrderSummary

--- a/src/components/orders/RecentOrdersTable/RecentOrdersTable.css
+++ b/src/components/orders/RecentOrdersTable/RecentOrdersTable.css
@@ -1,0 +1,127 @@
+.orders__table-card {
+  background: #ffffff;
+  border-radius: 24px;
+  padding: 24px;
+  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.orders__table-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
+.orders__table-title h3 {
+  margin: 0;
+  font-size: 22px;
+  color: #0f172a;
+}
+
+.orders__table-title p {
+  margin: 4px 0 0;
+  color: #64748b;
+}
+
+.orders__filters {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.orders__filter {
+  border: 1px solid #cbd5f5;
+  border-radius: 12px;
+  padding: 10px 14px;
+  background: #f8fafc;
+  color: #1e293b;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.orders__table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.orders__table thead {
+  background: #f1f5f9;
+  border-radius: 16px;
+}
+
+.orders__table th,
+.orders__table td {
+  text-align: left;
+  padding: 14px 16px;
+  font-size: 14px;
+  color: #1e293b;
+}
+
+.orders__table tbody tr + tr {
+  border-top: 1px solid #e2e8f0;
+}
+
+.orders__status {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.orders__status--success {
+  background: rgba(34, 197, 94, 0.15);
+  color: #15803d;
+}
+
+.orders__status--warning {
+  background: rgba(250, 204, 21, 0.2);
+  color: #a16207;
+}
+
+.orders__status--danger {
+  background: rgba(248, 113, 113, 0.2);
+  color: #b91c1c;
+}
+
+.orders__action {
+  border: none;
+  background: none;
+  color: #2563eb;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.orders__table-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  color: #64748b;
+}
+
+.orders__pagination {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.orders__pagination button {
+  border: none;
+  background: #e2e8f0;
+  padding: 8px 14px;
+  border-radius: 12px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+@media (max-width: 640px) {
+  .orders__table-card {
+    padding: 18px;
+  }
+}

--- a/src/components/orders/RecentOrdersTable/RecentOrdersTable.jsx
+++ b/src/components/orders/RecentOrdersTable/RecentOrdersTable.jsx
@@ -1,0 +1,57 @@
+import './RecentOrdersTable.css'
+
+const RecentOrdersTable = ({ orders, statusTone }) => (
+  <section className="orders__table-card">
+    <div className="orders__table-header">
+      <div className="orders__table-title">
+        <h3>Recent Orders</h3>
+        <p>Monitor order status and fulfillment progress.</p>
+      </div>
+      <div className="orders__filters">
+        <button type="button" className="orders__filter">All Statuses</button>
+        <button type="button" className="orders__filter">Select Date Range</button>
+        <button type="button" className="orders__filter">Filter by Route</button>
+      </div>
+    </div>
+    <table className="orders__table">
+      <thead>
+        <tr>
+          <th>Order ID</th>
+          <th>Customer</th>
+          <th>Date</th>
+          <th>Status</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {orders.map((order) => (
+          <tr key={order.id}>
+            <td>{order.id}</td>
+            <td>{order.customer}</td>
+            <td>{order.date}</td>
+            <td>
+              <span className={`orders__status orders__status--${statusTone[order.status]}`}>
+                {order.status}
+              </span>
+            </td>
+            <td>
+              <button type="button" className="orders__action">View</button>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+    <footer className="orders__table-footer">
+      <p>
+        Showing <strong>5</strong> of <strong>25</strong> orders
+      </p>
+      <div className="orders__pagination">
+        <button type="button">Previous</button>
+        <span>Page 1 of 2</span>
+        <button type="button">Next</button>
+      </div>
+    </footer>
+  </section>
+)
+
+export default RecentOrdersTable

--- a/src/components/reportOverview/ReportActions/ReportActions.css
+++ b/src/components/reportOverview/ReportActions/ReportActions.css
@@ -1,0 +1,23 @@
+.report-overview__actions {
+  display: flex;
+  gap: 12px;
+}
+
+.report-overview__button {
+  border: none;
+  border-radius: 12px;
+  padding: 12px 18px;
+  font-weight: 600;
+  background: #2563eb;
+  color: #ffffff;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.report-overview__button--secondary {
+  background: #0f172a;
+}
+
+.report-overview__button:hover {
+  transform: translateY(-1px);
+}

--- a/src/components/reportOverview/ReportActions/ReportActions.jsx
+++ b/src/components/reportOverview/ReportActions/ReportActions.jsx
@@ -1,0 +1,12 @@
+import './ReportActions.css'
+
+const ReportActions = () => (
+  <div className="report-overview__actions">
+    <button type="button" className="report-overview__button">Export PDF</button>
+    <button type="button" className="report-overview__button report-overview__button--secondary">
+      Download CSV
+    </button>
+  </div>
+)
+
+export default ReportActions

--- a/src/components/reportOverview/ReportFilters/ReportFilters.css
+++ b/src/components/reportOverview/ReportFilters/ReportFilters.css
@@ -1,0 +1,15 @@
+.report-overview__filters {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.report-overview__filter {
+  border: 1px solid #cbd5f5;
+  border-radius: 12px;
+  padding: 10px 14px;
+  background: #f8fafc;
+  color: #1e293b;
+  font-weight: 500;
+  cursor: pointer;
+}

--- a/src/components/reportOverview/ReportFilters/ReportFilters.jsx
+++ b/src/components/reportOverview/ReportFilters/ReportFilters.jsx
@@ -1,0 +1,13 @@
+import './ReportFilters.css'
+
+const ReportFilters = ({ filters }) => (
+  <div className="report-overview__filters">
+    {filters.map((filter) => (
+      <button key={filter.id} type="button" className="report-overview__filter">
+        <span>{filter.placeholder}</span>
+      </button>
+    ))}
+  </div>
+)
+
+export default ReportFilters

--- a/src/components/reportOverview/ReportHeader/ReportHeader.css
+++ b/src/components/reportOverview/ReportHeader/ReportHeader.css
@@ -1,0 +1,16 @@
+.report-overview__header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.report-overview__header h2 {
+  margin: 0;
+  font-size: 28px;
+  color: #0f172a;
+}
+
+.report-overview__header p {
+  margin: 0;
+  color: #64748b;
+}

--- a/src/components/reportOverview/ReportHeader/ReportHeader.jsx
+++ b/src/components/reportOverview/ReportHeader/ReportHeader.jsx
@@ -1,0 +1,10 @@
+import './ReportHeader.css'
+
+const ReportHeader = () => (
+  <header className="report-overview__header">
+    <h2>Report Overview</h2>
+    <p>Analyse key metrics across sales, operations, and customer behaviour.</p>
+  </header>
+)
+
+export default ReportHeader

--- a/src/components/reportOverview/ReportTable/ReportTable.css
+++ b/src/components/reportOverview/ReportTable/ReportTable.css
@@ -1,0 +1,60 @@
+.report-overview__card {
+  background: #ffffff;
+  border-radius: 24px;
+  padding: 24px;
+  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.report-overview__table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.report-overview__table thead {
+  background: #f1f5f9;
+}
+
+.report-overview__table th,
+.report-overview__table td {
+  text-align: left;
+  padding: 14px 16px;
+  font-size: 14px;
+  color: #1e293b;
+}
+
+.report-overview__table tbody tr + tr {
+  border-top: 1px solid #e2e8f0;
+}
+
+.report-overview__footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  color: #64748b;
+}
+
+.report-overview__pagination {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.report-overview__pagination button {
+  border: none;
+  background: #e2e8f0;
+  padding: 8px 14px;
+  border-radius: 12px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+@media (max-width: 640px) {
+  .report-overview__card {
+    padding: 18px;
+  }
+}

--- a/src/components/reportOverview/ReportTable/ReportTable.jsx
+++ b/src/components/reportOverview/ReportTable/ReportTable.jsx
@@ -1,0 +1,41 @@
+import './ReportTable.css'
+
+const ReportTable = ({ reports }) => (
+  <section className="report-overview__card">
+    <table className="report-overview__table">
+      <thead>
+        <tr>
+          <th>Report Type</th>
+          <th>Date</th>
+          <th>Route</th>
+          <th>Product Category</th>
+          <th>Sales Amount</th>
+          <th>Transactions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {reports.map((report) => (
+          <tr key={`${report.name}-${report.date}`}>
+            <td>{report.name}</td>
+            <td>{report.date}</td>
+            <td>{report.region}</td>
+            <td>{report.category}</td>
+            <td>{report.revenue}</td>
+            <td>{report.transactions}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+
+    <footer className="report-overview__footer">
+      <span>Showing 6 of 24 reports</span>
+      <div className="report-overview__pagination">
+        <button type="button">Previous</button>
+        <span>Page 1 of 4</span>
+        <button type="button">Next</button>
+      </div>
+    </footer>
+  </section>
+)
+
+export default ReportTable

--- a/src/components/trainSchedule/ScheduleAlerts/ScheduleAlerts.css
+++ b/src/components/trainSchedule/ScheduleAlerts/ScheduleAlerts.css
@@ -1,0 +1,55 @@
+.train-schedule__alerts {
+  display: grid;
+  gap: 16px;
+}
+
+.train-schedule__alert {
+  background: #ffffff;
+  border-radius: 18px;
+  padding: 18px 22px;
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.05);
+}
+
+.train-schedule__alert-indicator {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  margin-top: 6px;
+}
+
+.train-schedule__alert h3 {
+  margin: 0 0 6px;
+  font-size: 16px;
+  color: #0f172a;
+}
+
+.train-schedule__alert p {
+  margin: 0;
+  color: #475569;
+  font-size: 14px;
+}
+
+.train-schedule__alert--warning .train-schedule__alert-indicator {
+  background: #f59e0b;
+}
+
+.train-schedule__alert--error .train-schedule__alert-indicator {
+  background: #ef4444;
+}
+
+.train-schedule__alert--warning {
+  border-left: 6px solid rgba(245, 158, 11, 0.4);
+}
+
+.train-schedule__alert--error {
+  border-left: 6px solid rgba(239, 68, 68, 0.4);
+}
+
+@media (max-width: 640px) {
+  .train-schedule__alert {
+    flex-direction: column;
+  }
+}

--- a/src/components/trainSchedule/ScheduleAlerts/ScheduleAlerts.jsx
+++ b/src/components/trainSchedule/ScheduleAlerts/ScheduleAlerts.jsx
@@ -1,0 +1,17 @@
+import './ScheduleAlerts.css'
+
+const ScheduleAlerts = ({ alerts }) => (
+  <div className="train-schedule__alerts">
+    {alerts.map((alert) => (
+      <article key={alert.id} className={`train-schedule__alert train-schedule__alert--${alert.tone}`}>
+        <div className="train-schedule__alert-indicator" />
+        <div>
+          <h3>{alert.title}</h3>
+          <p>{alert.description}</p>
+        </div>
+      </article>
+    ))}
+  </div>
+)
+
+export default ScheduleAlerts

--- a/src/components/trainSchedule/ScheduleHeader/ScheduleHeader.css
+++ b/src/components/trainSchedule/ScheduleHeader/ScheduleHeader.css
@@ -1,0 +1,61 @@
+.train-schedule__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 24px;
+}
+
+.train-schedule__header h2 {
+  margin: 0;
+  font-size: 28px;
+  color: #0f172a;
+}
+
+.train-schedule__header p {
+  margin: 6px 0 0;
+  color: #64748b;
+}
+
+.train-schedule__actions {
+  display: flex;
+  gap: 12px;
+}
+
+.train-schedule__button {
+  border: none;
+  border-radius: 12px;
+  padding: 12px 18px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.train-schedule__button--primary {
+  background: #2563eb;
+  color: #ffffff;
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.2);
+}
+
+.train-schedule__button--secondary {
+  background: #0f172a;
+  color: #ffffff;
+}
+
+.train-schedule__button:hover {
+  transform: translateY(-1px);
+}
+
+@media (max-width: 960px) {
+  .train-schedule__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .train-schedule__actions {
+    width: 100%;
+  }
+
+  .train-schedule__actions button {
+    flex: 1;
+  }
+}

--- a/src/components/trainSchedule/ScheduleHeader/ScheduleHeader.jsx
+++ b/src/components/trainSchedule/ScheduleHeader/ScheduleHeader.jsx
@@ -1,0 +1,20 @@
+import './ScheduleHeader.css'
+
+const ScheduleHeader = () => (
+  <header className="train-schedule__header">
+    <div>
+      <h2>Train Schedule Overview</h2>
+      <p>Today, August 07, 2025</p>
+    </div>
+    <div className="train-schedule__actions">
+      <button type="button" className="train-schedule__button train-schedule__button--primary">
+        Add New Trip
+      </button>
+      <button type="button" className="train-schedule__button train-schedule__button--secondary">
+        Export Schedule
+      </button>
+    </div>
+  </header>
+)
+
+export default ScheduleHeader

--- a/src/components/trainSchedule/ScheduleTable/ScheduleTable.css
+++ b/src/components/trainSchedule/ScheduleTable/ScheduleTable.css
@@ -1,0 +1,117 @@
+.train-schedule__card {
+  background: #ffffff;
+  border-radius: 24px;
+  padding: 24px;
+  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.train-schedule__tabs {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.train-schedule__tab {
+  border: none;
+  padding: 10px 16px;
+  border-radius: 12px;
+  background: #e2e8f0;
+  color: #1e293b;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.train-schedule__tab--active {
+  background: #2563eb;
+  color: #ffffff;
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.2);
+}
+
+.train-schedule__table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.train-schedule__table thead {
+  background: #f1f5f9;
+}
+
+.train-schedule__table th,
+.train-schedule__table td {
+  padding: 14px 16px;
+  text-align: left;
+  font-size: 14px;
+  color: #1f2937;
+}
+
+.train-schedule__table tbody tr + tr {
+  border-top: 1px solid #e2e8f0;
+}
+
+.train-schedule__status {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.train-schedule__status--success {
+  background: rgba(34, 197, 94, 0.15);
+  color: #16a34a;
+}
+
+.train-schedule__status--warning {
+  background: rgba(250, 204, 21, 0.2);
+  color: #a16207;
+}
+
+.train-schedule__status--danger {
+  background: rgba(248, 113, 113, 0.2);
+  color: #b91c1c;
+}
+
+.train-schedule__status--neutral {
+  background: rgba(59, 130, 246, 0.15);
+  color: #1d4ed8;
+}
+
+.train-schedule__footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  color: #64748b;
+}
+
+.train-schedule__pagination {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.train-schedule__pagination button {
+  border: none;
+  background: #e2e8f0;
+  padding: 8px 14px;
+  border-radius: 12px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.train-schedule__pagination .is-active {
+  background: #2563eb;
+  color: #ffffff;
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.2);
+}
+
+@media (max-width: 640px) {
+  .train-schedule__card {
+    padding: 18px;
+  }
+}

--- a/src/components/trainSchedule/ScheduleTable/ScheduleTable.jsx
+++ b/src/components/trainSchedule/ScheduleTable/ScheduleTable.jsx
@@ -1,0 +1,58 @@
+import './ScheduleTable.css'
+
+const ScheduleTable = ({ trips, statusTone }) => (
+  <section className="train-schedule__card">
+    <header className="train-schedule__tabs">
+      <button type="button" className="train-schedule__tab train-schedule__tab--active">
+        Train Schedule
+      </button>
+      <button type="button" className="train-schedule__tab">Truck Schedule</button>
+      <button type="button" className="train-schedule__tab">Assigned Orders</button>
+    </header>
+
+    <table className="train-schedule__table">
+      <thead>
+        <tr>
+          <th>Departure</th>
+          <th>Train ID</th>
+          <th>Assigned Orders</th>
+          <th>Capacity</th>
+          <th>Status</th>
+          <th>Train Lead</th>
+          <th>Route</th>
+        </tr>
+      </thead>
+      <tbody>
+        {trips.map((trip) => (
+          <tr key={trip.id}>
+            <td>{trip.time}</td>
+            <td>{trip.id}</td>
+            <td>{trip.assigned}</td>
+            <td>{trip.capacity}</td>
+            <td>
+              <span className={`train-schedule__status train-schedule__status--${statusTone[trip.status]}`}>
+                {trip.status}
+              </span>
+            </td>
+            <td>{trip.lead}</td>
+            <td>{trip.route}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+
+    <footer className="train-schedule__footer">
+      <span>Showing 6 of 12 trips</span>
+      <div className="train-schedule__pagination">
+        <button type="button">1</button>
+        <button type="button" className="is-active">
+          2
+        </button>
+        <button type="button">3</button>
+        <button type="button">Next &rsaquo;</button>
+      </div>
+    </footer>
+  </section>
+)
+
+export default ScheduleTable

--- a/src/components/userManagement/UserManagementHeader/UserManagementHeader.css
+++ b/src/components/userManagement/UserManagementHeader/UserManagementHeader.css
@@ -1,0 +1,59 @@
+.user-management__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 24px;
+}
+
+.user-management__header h2 {
+  margin: 0;
+  font-size: 28px;
+  color: #0f172a;
+}
+
+.user-management__header p {
+  margin: 6px 0 0;
+  color: #64748b;
+}
+
+.user-management__header-actions {
+  display: flex;
+  gap: 12px;
+}
+
+.user-management__header-actions input {
+  flex: 1;
+  min-width: 220px;
+  padding: 12px 16px;
+  border-radius: 12px;
+  border: 1px solid #cbd5f5;
+  background: #f8fafc;
+}
+
+.user-management__header-actions button {
+  border: none;
+  border-radius: 12px;
+  padding: 12px 18px;
+  font-weight: 600;
+  background: #2563eb;
+  color: #ffffff;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.user-management__header-actions button:hover {
+  transform: translateY(-1px);
+}
+
+@media (max-width: 960px) {
+  .user-management__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .user-management__header-actions {
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+  }
+}

--- a/src/components/userManagement/UserManagementHeader/UserManagementHeader.jsx
+++ b/src/components/userManagement/UserManagementHeader/UserManagementHeader.jsx
@@ -1,0 +1,16 @@
+import './UserManagementHeader.css'
+
+const UserManagementHeader = () => (
+  <header className="user-management__header">
+    <div>
+      <h2>User Management</h2>
+      <p>Manage roles, permissions, and account access for your team.</p>
+    </div>
+    <div className="user-management__header-actions">
+      <input type="search" placeholder="Search users..." />
+      <button type="button">Add User</button>
+    </div>
+  </header>
+)
+
+export default UserManagementHeader

--- a/src/components/userManagement/UserManagementTable/UserManagementTable.css
+++ b/src/components/userManagement/UserManagementTable/UserManagementTable.css
@@ -1,0 +1,156 @@
+.user-management__card {
+  background: #ffffff;
+  border-radius: 24px;
+  padding: 24px;
+  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.user-management__table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.user-management__table thead {
+  background: #f1f5f9;
+}
+
+.user-management__table th,
+.user-management__table td {
+  text-align: left;
+  padding: 14px 16px;
+  font-size: 14px;
+  color: #1e293b;
+}
+
+.user-management__table tbody tr + tr {
+  border-top: 1px solid #e2e8f0;
+}
+
+.user-management__role {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.user-management__role--danger {
+  background: rgba(248, 113, 113, 0.2);
+  color: #b91c1c;
+}
+
+.user-management__role--warning {
+  background: rgba(250, 204, 21, 0.2);
+  color: #a16207;
+}
+
+.user-management__role--info {
+  background: rgba(96, 165, 250, 0.2);
+  color: #1d4ed8;
+}
+
+.user-management__toggle {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  width: 44px;
+  height: 24px;
+}
+
+.user-management__toggle input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.user-management__slider {
+  position: absolute;
+  inset: 0;
+  background: #cbd5f5;
+  border-radius: 999px;
+  transition: background 0.2s ease;
+}
+
+.user-management__slider::before {
+  content: '';
+  position: absolute;
+  height: 18px;
+  width: 18px;
+  left: 3px;
+  bottom: 3px;
+  background-color: white;
+  border-radius: 50%;
+  transition: transform 0.2s ease;
+  box-shadow: 0 4px 8px rgba(15, 23, 42, 0.1);
+}
+
+.user-management__toggle input:checked + .user-management__slider {
+  background: #2563eb;
+}
+
+.user-management__toggle input:checked + .user-management__slider::before {
+  transform: translateX(20px);
+}
+
+.user-management__actions {
+  display: flex;
+  gap: 8px;
+}
+
+.user-management__icon-button {
+  border: none;
+  border-radius: 10px;
+  padding: 8px 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.user-management__icon-button--edit {
+  background: rgba(37, 99, 235, 0.15);
+  color: #1d4ed8;
+}
+
+.user-management__icon-button--delete {
+  background: rgba(248, 113, 113, 0.15);
+  color: #b91c1c;
+}
+
+.user-management__footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  color: #64748b;
+}
+
+.user-management__pagination {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.user-management__pagination button {
+  border: none;
+  background: #e2e8f0;
+  padding: 8px 14px;
+  border-radius: 12px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.user-management__pagination .is-active {
+  background: #2563eb;
+  color: #ffffff;
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.2);
+}
+
+@media (max-width: 640px) {
+  .user-management__card {
+    padding: 18px;
+  }
+}

--- a/src/components/userManagement/UserManagementTable/UserManagementTable.jsx
+++ b/src/components/userManagement/UserManagementTable/UserManagementTable.jsx
@@ -1,0 +1,63 @@
+import './UserManagementTable.css'
+
+const UserManagementTable = ({ users, roleTone }) => (
+  <section className="user-management__card">
+    <table className="user-management__table">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Email</th>
+          <th>Role</th>
+          <th>Status</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {users.map((user) => (
+          <tr key={user.email}>
+            <td>{user.name}</td>
+            <td>{user.email}</td>
+            <td>
+              <span className={`user-management__role user-management__role--${roleTone[user.role]}`}>
+                {user.role}
+              </span>
+            </td>
+            <td>
+              <label className="user-management__toggle">
+                <input type="checkbox" checked={user.status} readOnly />
+                <span className="user-management__slider" />
+              </label>
+            </td>
+            <td>
+              <div className="user-management__actions">
+                <button type="button" className="user-management__icon-button user-management__icon-button--edit">
+                  Edit
+                </button>
+                <button type="button" className="user-management__icon-button user-management__icon-button--delete">
+                  Delete
+                </button>
+              </div>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+
+    <footer className="user-management__footer">
+      <span>Showing 6 of 18 users</span>
+      <div className="user-management__pagination">
+        <button type="button">Previous</button>
+        <div>
+          <button type="button" className="is-active">
+            1
+          </button>
+          <button type="button">2</button>
+          <button type="button">3</button>
+        </div>
+        <button type="button">Next</button>
+      </div>
+    </footer>
+  </section>
+)
+
+export default UserManagementTable

--- a/src/pages/Orders/Orders.css
+++ b/src/pages/Orders/Orders.css
@@ -1,0 +1,5 @@
+.orders {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}

--- a/src/pages/Orders/Orders.jsx
+++ b/src/pages/Orders/Orders.jsx
@@ -1,0 +1,56 @@
+import OrderSummary from '../../components/orders/OrderSummary/OrderSummary'
+import OrderStats from '../../components/orders/OrderStats/OrderStats'
+import RecentOrdersTable from '../../components/orders/RecentOrdersTable/RecentOrdersTable'
+import './Orders.css'
+
+const orderStats = [
+  {
+    id: 'total',
+    title: 'Total Orders',
+    value: '1,280',
+    hint: '+15% from last month',
+  },
+  {
+    id: 'pending',
+    title: 'Pending',
+    value: '125',
+    hint: 'Awaiting fulfillment',
+  },
+  {
+    id: 'delivered',
+    title: 'Delivered',
+    value: '1,155',
+    hint: '90% completion rate',
+  },
+  {
+    id: 'average',
+    title: 'Avg. Order Value',
+    value: 'LKR 325,505',
+    hint: 'Updated 1 hour ago',
+    accent: 'highlight',
+  },
+]
+
+const recentOrders = [
+  { id: 'ORD001', customer: 'Alice Smith', date: '2025-08-02', status: 'Delivered' },
+  { id: 'ORD002', customer: 'Bob Johnson', date: '2025-08-12', status: 'Pending' },
+  { id: 'ORD003', customer: 'Charlie Brown', date: '2025-08-13', status: 'Canceled' },
+  { id: 'ORD004', customer: 'Diana Prince', date: '2025-08-16', status: 'Delivered' },
+  { id: 'ORD005', customer: 'Eva Adams', date: '2025-08-18', status: 'Pending' },
+]
+
+const statusTone = {
+  Delivered: 'success',
+  Pending: 'warning',
+  Canceled: 'danger',
+}
+
+const Orders = () => (
+  <div className="orders">
+    <OrderSummary />
+    <OrderStats stats={orderStats} />
+    <RecentOrdersTable orders={recentOrders} statusTone={statusTone} />
+  </div>
+)
+
+export default Orders

--- a/src/pages/ReportOverview/ReportOverview.css
+++ b/src/pages/ReportOverview/ReportOverview.css
@@ -1,0 +1,5 @@
+.report-overview {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}

--- a/src/pages/ReportOverview/ReportOverview.jsx
+++ b/src/pages/ReportOverview/ReportOverview.jsx
@@ -1,0 +1,74 @@
+import ReportHeader from '../../components/reportOverview/ReportHeader/ReportHeader'
+import ReportFilters from '../../components/reportOverview/ReportFilters/ReportFilters'
+import ReportActions from '../../components/reportOverview/ReportActions/ReportActions'
+import ReportTable from '../../components/reportOverview/ReportTable/ReportTable'
+import './ReportOverview.css'
+
+const filters = [
+  { id: 'type', label: 'Report Type', placeholder: 'Daily Sales' },
+  { id: 'date', label: 'Select Date Range', placeholder: 'Select Date Range' },
+  { id: 'route', label: 'Filter by Route', placeholder: 'Filter by Route' },
+  { id: 'category', label: 'All Categories', placeholder: 'All Categories' },
+]
+
+const reports = [
+  {
+    name: 'Daily Sales',
+    date: '2024-03-31',
+    region: 'North Region',
+    category: 'Electronics',
+    revenue: 'Rs. 1,245,000',
+    transactions: 340,
+  },
+  {
+    name: 'Monthly Revenue',
+    date: '2024-03-01',
+    region: 'South Region',
+    category: 'Apparel',
+    revenue: 'Rs. 8,765,500',
+    transactions: 90,
+  },
+  {
+    name: 'Product Performance',
+    date: '2024-03-15',
+    region: 'East Region',
+    category: 'Home Goods',
+    revenue: 'Rs. 3,540,000',
+    transactions: 210,
+  },
+  {
+    name: 'User Activity',
+    date: '2024-03-18',
+    region: 'West Region',
+    category: 'Food & Beverage',
+    revenue: 'Rs. 2,450,900',
+    transactions: 150,
+  },
+  {
+    name: 'Product Performance',
+    date: '2024-03-22',
+    region: 'Central Region',
+    category: 'Apparel',
+    revenue: 'Rs. 1,780,000',
+    transactions: 120,
+  },
+  {
+    name: 'Daily Sales',
+    date: '2024-03-27',
+    region: 'North Region',
+    category: 'Electronics',
+    revenue: 'Rs. 1,125,000',
+    transactions: 290,
+  },
+]
+
+const ReportOverview = () => (
+  <div className="report-overview">
+    <ReportHeader />
+    <ReportFilters filters={filters} />
+    <ReportActions />
+    <ReportTable reports={reports} />
+  </div>
+)
+
+export default ReportOverview

--- a/src/pages/TrainSchedule/TrainSchedule.css
+++ b/src/pages/TrainSchedule/TrainSchedule.css
@@ -1,0 +1,5 @@
+.train-schedule {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}

--- a/src/pages/TrainSchedule/TrainSchedule.jsx
+++ b/src/pages/TrainSchedule/TrainSchedule.jsx
@@ -1,0 +1,93 @@
+import ScheduleHeader from '../../components/trainSchedule/ScheduleHeader/ScheduleHeader'
+import ScheduleAlerts from '../../components/trainSchedule/ScheduleAlerts/ScheduleAlerts'
+import ScheduleTable from '../../components/trainSchedule/ScheduleTable/ScheduleTable'
+import './TrainSchedule.css'
+
+const alerts = [
+  {
+    id: 'TR102',
+    title: 'Conflict Detected: TR-102 Overbooked',
+    description: 'Train TR-5678 is assigned 13 units but has a max capacity of 12 units. Review ASAP.',
+    tone: 'warning',
+  },
+  {
+    id: 'TR702',
+    title: 'Conflict Detected: TR-702 Overbooked',
+    description: 'Train TR-702 is assigned 210 units but has a max capacity of 200 units. Immediate action required.',
+    tone: 'error',
+  },
+]
+
+const trips = [
+  {
+    time: '08:00 AM',
+    id: 'T-001',
+    assigned: 120,
+    capacity: 150,
+    status: 'Available',
+    lead: 'Alice Johnson',
+    route: 'Colombo to Jaffna',
+  },
+  {
+    time: '10:30 AM',
+    id: 'T-002',
+    assigned: 90,
+    capacity: 120,
+    status: 'Available',
+    lead: 'Bob Williams',
+    route: 'Colombo to Kandy',
+  },
+  {
+    time: '01:15 PM',
+    id: 'T-004',
+    assigned: 138,
+    capacity: 140,
+    status: 'Warning',
+    lead: 'Charlie Brown',
+    route: 'Colombo to Galle',
+  },
+  {
+    time: '03:20 PM',
+    id: 'T-006',
+    assigned: 160,
+    capacity: 150,
+    status: 'Overbooked',
+    lead: 'Diana Prince',
+    route: 'Colombo to Batticaloa',
+  },
+  {
+    time: '05:30 PM',
+    id: 'T-008',
+    assigned: 200,
+    capacity: 200,
+    status: 'At Capacity',
+    lead: 'Ethan Hunt',
+    route: 'Colombo to Trincomalee',
+  },
+  {
+    time: '07:15 PM',
+    id: 'T-009',
+    assigned: 80,
+    capacity: 130,
+    status: 'Available',
+    lead: 'Grace Hopper',
+    route: 'Colombo to Matara',
+  },
+]
+
+const statusTone = {
+  Available: 'success',
+  Warning: 'warning',
+  Overbooked: 'danger',
+  'At Capacity': 'neutral',
+}
+
+const TrainSchedule = () => (
+  <div className="train-schedule">
+    <ScheduleHeader />
+    <ScheduleAlerts alerts={alerts} />
+    <ScheduleTable trips={trips} statusTone={statusTone} />
+  </div>
+)
+
+export default TrainSchedule

--- a/src/pages/UserManagement/UserManagement.css
+++ b/src/pages/UserManagement/UserManagement.css
@@ -1,0 +1,5 @@
+.user-management {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}

--- a/src/pages/UserManagement/UserManagement.jsx
+++ b/src/pages/UserManagement/UserManagement.jsx
@@ -1,0 +1,27 @@
+import UserManagementHeader from '../../components/userManagement/UserManagementHeader/UserManagementHeader'
+import UserManagementTable from '../../components/userManagement/UserManagementTable/UserManagementTable'
+import './UserManagement.css'
+
+const users = [
+  { name: 'Alice Johnson', email: 'alice@example.com', role: 'Admin', status: true },
+  { name: 'Bob Williams', email: 'bob@example.com', role: 'Editor', status: true },
+  { name: 'Charlie Brown', email: 'charlie@example.com', role: 'Editor', status: false },
+  { name: 'Diana Prince', email: 'diana@example.com', role: 'Viewer', status: true },
+  { name: 'Ethan Hunt', email: 'ethan@example.com', role: 'Viewer', status: false },
+  { name: 'Fiona Apple', email: 'fiona@example.com', role: 'Viewer', status: true },
+]
+
+const roleTone = {
+  Admin: 'danger',
+  Editor: 'warning',
+  Viewer: 'info',
+}
+
+const UserManagement = () => (
+  <div className="user-management">
+    <UserManagementHeader />
+    <UserManagementTable users={users} roleTone={roleTone} />
+  </div>
+)
+
+export default UserManagement


### PR DESCRIPTION
## Summary
- refactor Orders, Train Schedule, Report Overview, and User Management pages to assemble their layouts from page-scoped components
- move markup styling into component-specific CSS files under src/components while keeping page shells minimal for layout
- preserve existing datasets and behaviour through props passed into each extracted component

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e33d33af748329836f3e7cf78fc6ad